### PR TITLE
Replace Autoplay GIFs plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -62,9 +62,9 @@
         }, 
         {
             "name": "Autoplay GIFS",
-            "author": "Jiiks",
+            "author": "noodlebox",
             "description": "Automatically play gifs without having to hover",
-            "url": "https://raw.githubusercontent.com/Jiiks/BetterDiscordApp/master/Plugins/AutoPlayGifs.plugin.js"
+            "url": "https://raw.githubusercontent.com/noodlebox/betterdiscord-plugins/master/AutoPlayGifs.plugin.js"
         }, 
         {
             "name": "Custom role colour",


### PR DESCRIPTION
Replaces AutoPlayGifs.plugin.js with a working version.

I replaced the old entry instead of adding a new one because this is meant to be a drop-in replacement, which would conflict with the old one if installed alongside it.