### PR TITLE
changed lines 30 and 31 to actual linux theme and plugins folders.

### DIFF
--- a/evenBetterRepo.plugin.js
+++ b/evenBetterRepo.plugin.js
@@ -26,8 +26,8 @@ evenBetterRepo.prototype.load = function(){
         this.themePath = process.env.APPDATA + "\\BetterDiscord\\themes\\";
         this.pluginPath = process.env.APPDATA + "\\BetterDiscord\\plugins\\";
     } else if (process.platform == "linux"){
-        this.themePath= process.env.HOME + "/.config/BetterDiscord/themes/";
-        this.pluginPath= process.env.HOME + "/.config/BetterDiscord/plugins/";
+        "var/local/BetterDiscord/themes/";
+        "var/local/BetterDiscord/plugins/";
     } else if (process.platform == "darwin"){
         this.themePath = process.env.HOME + "/Library/Preferences/BetterDiscord/themes/";
         this.pluginPath = process.env.HOME + "/Library/Preferences/BetterDiscord/plugins/";


### PR DESCRIPTION
The Directory used by the BetterDiscord install seems to be in /var/local/BetterDiscord for now. since the path seems to be static, that should work for now. 